### PR TITLE
rel 1.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14.0)
-project(gic400.library VERSION 1.3.0)
+project(gic400.library VERSION 1.4.0)
 
 # Version string
 string(TIMESTAMP CURRENT_DATE "(%d.%m.%Y)")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,9 @@ target_link_libraries(gic400_library
         Emu68Common::common
 )
 
+# ROM-able: no writable .data/.bss may sneak in (see driver-stack TODO.md)
+emu68_rom_check(gic400_library)
+
 set_target_properties(gic400_library PROPERTIES
     OUTPUT_NAME gic400
     SUFFIX ".library"

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This repository is dual-licensed under `MPL-2.0 OR GPL-2.0+`. File-level SPDX he
 - Device-tree driven discovery of distributor/CPU interface base addresses under Emu68.
 - Helper APIs for querying interrupt state, changing trigger modes, routing, and priority masks.
 - Optional debug logging to aid bring-up on new firmware or board revisions.
+- ROM-able: the linked binary contains no writable `.data`/`.bss`, with all mutable state held in the allocated library base. A build-time check (`emu68_rom_check`) enforces this.
 
 ## Unimplemented / Planned Features
 

--- a/include/gic400_private.h
+++ b/include/gic400_private.h
@@ -45,7 +45,7 @@
 #endif
 
 #ifndef LIBRARY_PRIORITY
-#define LIBRARY_PRIORITY 0
+#define LIBRARY_PRIORITY 126
 #endif
 
 /* GIC Base structure */


### PR DESCRIPTION
This pull request updates the `gic400.library` project to version 1.4.0 and introduces improvements to ROM compatibility and configuration. The most significant changes include enforcing ROM-ability by ensuring no writable data sections are present, updating documentation, and adjusting the default library priority.

**ROM compatibility improvements:**
* Added the `emu68_rom_check` to the build process in `CMakeLists.txt` to ensure the linked binary contains no writable `.data` or `.bss` sections, making the library ROM-able. This is documented in both the build script and the `README.md`. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR112-R114) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R18)

**Configuration and versioning:**
* Updated the project version from 1.3.0 to 1.4.0 in `CMakeLists.txt`.
* Changed the default `LIBRARY_PRIORITY` from `0` to `126` in `gic400_private.h` to better align with system requirements.